### PR TITLE
Handle hidden Dockets

### DIFF
--- a/rule_scout.py
+++ b/rule_scout.py
@@ -31,7 +31,7 @@ class Docket:
     id: str
     title: str
     url: str
-    type: Literal['rulemaking', 'nonrulemaking']
+    type: Literal['rulemaking', 'nonrulemaking', 'hidden']
     keywords: list[str] = field(default_factory=list)
     rin: str | None = None
     # Agency-specific, but we want them for analysis and classification.
@@ -76,7 +76,7 @@ class Docket:
                 for x in [attributes['subType'], attributes['subType2']]
                 if x
             ],
-            category=attributes.get('category')
+            category=attributes.get('category'),
         )
 
 

--- a/rule_scout.py
+++ b/rule_scout.py
@@ -337,9 +337,29 @@ class RegulationsGovApi(HttpClient):
             headers={'X-Api-Key': api_key},
         )
 
-    def get_docket(self, docket_id) -> dict:
+    def get_docket(self, docket_id: str) -> dict:
         response = self.get(url=f'/dockets/{docket_id}')
         return response.raise_for_status().json()['data']
+
+    def get_docket_object(self, docket_id: str, if_missing: Literal['raise', 'hidden'] = 'raise') -> Docket:
+        """
+        Get a parsed ``Docket`` object representing the docket. If no docket
+        is found with the given ID, ``if_missing`` controls the result. If it
+        is ``'raise'`` (the default), this will raise an exception. If
+        ``'hidden'`` this will return a "hidden" Docket object with no data.
+        """
+        try:
+            return Docket.from_api(self.get_docket(docket_id))
+        except httpx.HTTPStatusError as error:
+            if if_missing == 'hidden' and error.response.status_code == 404:
+                return Docket(
+                    id=docket_id,
+                    title=docket_id,
+                    url='',
+                    type='hidden'
+                )
+            else:
+                raise
 
     def get_document(self, document_id) -> dict:
         response = self.get(url=f'/documents/{document_id}')
@@ -464,7 +484,7 @@ def main() -> None:
                     if docket_id:
                         docket = docket_cache.get(docket_id)
                         if not docket:
-                            docket = Docket.from_api(regulations_gov.get_docket(docket_id))
+                            docket = regulations_gov.get_docket_object(docket_id, if_missing='hidden')
                             docket_cache[docket_id] = docket
 
                         document.docket = docket

--- a/update_known_rules.py
+++ b/update_known_rules.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from httpx import HTTPStatusError
 from os import getenv
 from rule_scout import (
     NOTION_RULE_DATABASE,
@@ -103,14 +102,7 @@ def get_page_updates(regulations_gov: RegulationsGovApi, page: dict) -> dict[str
             docket = DOCKET_CACHE.get(docket_id)
             if not docket:
                 time.sleep(REGULATIONS_GOV_REQUEST_INTERVAL)
-                try:
-                    docket = Docket.from_api(regulations_gov.get_docket(docket_id))
-                except HTTPStatusError as error:
-                    # TODO: should probably have a nicer error class for this.
-                    if error.response.status_code == 404:
-                        docket = Docket(id=docket_id, title=str(docket_id), url='', type='hidden')
-                    else:
-                        raise
+                docket = regulations_gov.get_docket_object(docket_id, if_missing='hidden')
                 DOCKET_CACHE[docket_id] = docket
 
             new_keywords.update(docket.keywords)

--- a/update_known_rules.py
+++ b/update_known_rules.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from httpx import HTTPStatusError
 from os import getenv
 from rule_scout import (
     NOTION_RULE_DATABASE,
@@ -19,7 +20,6 @@ ALWAYS_UPDATE_DOCKET_DATA = False
 # Basic rate limit is 1,000/hour, or 1 request every 3.6 seconds. Based on:
 # https://api.data.gov/docs/developer-manual/
 REGULATIONS_GOV_REQUEST_INTERVAL = 3.6
-
 
 # TODO: consider how to better implement this. The easy thing is to put
 # @lru_cache on the RegulationsGovApi.get_docket method, but that could
@@ -103,7 +103,14 @@ def get_page_updates(regulations_gov: RegulationsGovApi, page: dict) -> dict[str
             docket = DOCKET_CACHE.get(docket_id)
             if not docket:
                 time.sleep(REGULATIONS_GOV_REQUEST_INTERVAL)
-                docket = Docket.from_api(regulations_gov.get_docket(docket_id))
+                try:
+                    docket = Docket.from_api(regulations_gov.get_docket(docket_id))
+                except HTTPStatusError as error:
+                    # TODO: should probably have a nicer error class for this.
+                    if error.response.status_code == 404:
+                        docket = Docket(id=docket_id, title=str(docket_id), url='', type='hidden')
+                    else:
+                        raise
                 DOCKET_CACHE[docket_id] = docket
 
             new_keywords.update(docket.keywords)


### PR DESCRIPTION
We currently have the update script failing because a proposed rule references a “hidden” docket (one where you can see the individual documents, but not the docket itself; I think this is usually because the agency in question manages its dockets separately, outside regulations.gov) and it raises a “not found” exception.

This fixes the issue by making converting the exception into a simplistic “hidden” `Docket` object with no real data in cases where we are sure the Docket ID is correct, and we just can’t load it.